### PR TITLE
feat: add stack trace to the recovery handler

### DIFF
--- a/grpc/options.go
+++ b/grpc/options.go
@@ -9,10 +9,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// grpcPanicRecoveryHandler handles panics and logs the incident.
+// grpcPanicRecoveryHandler handles panics and logs the incident with a stack trace.
 func grpcPanicRecoveryHandler(logger *zap.Logger) recovery.RecoveryHandlerFunc {
 	return func(p any) (err error) {
-		logger.Info("Recovered from panic", zap.Any("panic", p))
+		logger.Error("Recovered from panic", zap.Any("panic", p), zap.Stack("stack"))
 		return status.Errorf(codes.Internal, "Recovered from panic: %v", p)
 	}
 }


### PR DESCRIPTION
bitte approven, danke

# Beispiel

Ohne stack trace:
```
2024-06-23T17:12:18.359Z    INFO    cmd/main.go:92    Starting user-service v0.1.0 on port 50056    {"service": "user-service"}
2024-06-23T17:12:25.162Z    INFO    logging/logging.go:202    started call    {"service": "user-service", "traceID": "299bfe85861ef85d4fe6ee29181aa282", "protocol": "grpc", "grpc.component": "server", "grpc.service": "serveralpha.user.UserService", "grpc.method": "GetUser", "grpc.method_type": "unary", "peer.address": "10.244.0.174:47916", "grpc.start_time": "2024-06-23T17:12:25Z", "grpc.request.deadline": "2024-06-23T17:12:28Z", "grpc.time_ms": "0.008"}
2024-06-23T17:12:25.169Z    INFO    grpc/options.go:15    Recovered from panic    {"service": "user-service", "panic": "This is a test panic"}
2024-06-23T17:12:25.169Z    ERROR    logging/logging.go:202    finished call    {"service": "user-service", "traceID": "299bfe85861ef85d4fe6ee29181aa282", "protocol": "grpc", "grpc.component": "server", "grpc.service": "serveralpha.user.UserService", "grpc.method": "GetUser", "grpc.method_type": "unary", "peer.address": "10.244.0.174:47916", "grpc.start_time": "2024-06-23T17:12:25Z", "grpc.request.deadline": "2024-06-23T17:12:28Z", "grpc.code": "Internal", "grpc.error": "rpc error: code = Internal desc = Recovered from panic: This is a test panic", "grpc.time_ms": "6.72"}
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.LoggerFunc.Log
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/logging/logging.go:202
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.(*reporter).PostCall
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/logging/interceptors.go:44
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.UnaryServerInterceptor.UnaryServerInterceptor.func2
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/server.go:25
google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1187
github.com/wwi21seb-projekt/alpha-shared/proto/user._UserService_GetUser_Handler
    /go/pkg/mod/github.com/wwi21seb-projekt/alpha-shared@v0.21.0/proto/user/user-service_grpc.pb.go:461
google.golang.org/grpc.(*Server).processUnaryRPC
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1379
google.golang.org/grpc.(*Server).handleStream
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1029
```

Mit stack trace:
```
2024-06-23T17:16:40.369Z    INFO    cmd/main.go:92    Starting user-service v0.1.0 on port 50056    {"service": "user-service"}
2024-06-23T17:16:58.699Z    INFO    logging/logging.go:202    started call    {"service": "user-service", "traceID": "6f32b034269a03922d7028dd156bc081", "protocol": "grpc", "grpc.component": "server", "grpc.service": "serveralpha.user.UserService", "grpc.method": "GetUser", "grpc.method_type": "unary", "peer.address": "10.244.0.180:52050", "grpc.start_time": "2024-06-23T17:16:58Z", "grpc.request.deadline": "2024-06-23T17:17:01Z", "grpc.time_ms": "0.008"}
2024-06-23T17:16:58.712Z    ERROR    grpc/options.go:15    Recovered from panic    {"service": "user-service", "panic": "This is a test panic", "stack": "github.com/wwi21seb-projekt/alpha-shared/grpc.NewServerOptions.grpcPanicRecoveryHandler.func3\n\t/go/pkg/mod/github.com/wwi21seb-projekt/alpha-shared@v0.21.2-0.20240623170543-b86b7a8bf346/grpc/options.go:15\ngithub.com/wwi21seb-projekt/alpha-shared/grpc.NewServerOptions.WithRecoveryHandler.func4.1\n\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/options.go:36\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.recoverFrom\n\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:54\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1.1\n\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:30\nruntime.gopanic\n\t/usr/local/go/src/runtime/panic.go:770\ngithub.com/wwi21seb-projekt/alpha-services/src/user-service/handler.userService.GetUser\n\t/go/src/serveralpha/handler/user.go:55\ngithub.com/wwi21seb-projekt/alpha-shared/proto/user._UserService_GetUser_Handler.func1\n\t/go/pkg/mod/github.com/wwi21seb-projekt/alpha-shared@v0.21.2-0.20240623170543-b86b7a8bf346/proto/user/user-service_grpc.pb.go:459\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1\n\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:34\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1196\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.UnaryServerInterceptor.UnaryServerInterceptor.func2\n\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/server.go:22\ngoogle.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1\n\t/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1187\ngithub.com/wwi21seb-projekt/alpha-shared/proto/user._UserService_GetUser_Handler\n\t/go/pkg/mod/github.com/wwi21seb-projekt/alpha-shared@v0.21.2-0.20240623170543-b86b7a8bf346/proto/user/user-service_grpc.pb.go:461\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1379\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1790\ngoogle.golang.org/grpc.(*Server).serveStreams.func2.1\n\t/go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1029"}
github.com/wwi21seb-projekt/alpha-shared/grpc.NewServerOptions.grpcPanicRecoveryHandler.func3
    /go/pkg/mod/github.com/wwi21seb-projekt/alpha-shared@v0.21.2-0.20240623170543-b86b7a8bf346/grpc/options.go:15
github.com/wwi21seb-projekt/alpha-shared/grpc.NewServerOptions.WithRecoveryHandler.func4.1
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/options.go:36
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.recoverFrom
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:54
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1.1
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:30
runtime.gopanic
    /usr/local/go/src/runtime/panic.go:770
github.com/wwi21seb-projekt/alpha-services/src/user-service/handler.userService.GetUser
    /go/src/serveralpha/handler/user.go:55
github.com/wwi21seb-projekt/alpha-shared/proto/user._UserService_GetUser_Handler.func1
    /go/pkg/mod/github.com/wwi21seb-projekt/alpha-shared@v0.21.2-0.20240623170543-b86b7a8bf346/proto/user/user-service_grpc.pb.go:459
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:34
google.golang.org/grpc.getChainUnaryHandler.func1
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1196
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.UnaryServerInterceptor.UnaryServerInterceptor.func2
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/server.go:22
google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1187
github.com/wwi21seb-projekt/alpha-shared/proto/user._UserService_GetUser_Handler
    /go/pkg/mod/github.com/wwi21seb-projekt/alpha-shared@v0.21.2-0.20240623170543-b86b7a8bf346/proto/user/user-service_grpc.pb.go:461
google.golang.org/grpc.(*Server).processUnaryRPC
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1379
google.golang.org/grpc.(*Server).handleStream
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1029
2024-06-23T17:16:58.712Z    ERROR    logging/logging.go:202    finished call    {"service": "user-service", "traceID": "6f32b034269a03922d7028dd156bc081", "protocol": "grpc", "grpc.component": "server", "grpc.service": "serveralpha.user.UserService", "grpc.method": "GetUser", "grpc.method_type": "unary", "peer.address": "10.244.0.180:52050", "grpc.start_time": "2024-06-23T17:16:58Z", "grpc.request.deadline": "2024-06-23T17:17:01Z", "grpc.code": "Internal", "grpc.error": "rpc error: code = Internal desc = Recovered from panic: This is a test panic", "grpc.time_ms": "12.802"}
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.LoggerFunc.Log
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/logging/logging.go:202
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.(*reporter).PostCall
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/logging/interceptors.go:44
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.UnaryServerInterceptor.UnaryServerInterceptor.func2
    /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/server.go:25
google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1187
github.com/wwi21seb-projekt/alpha-shared/proto/user._UserService_GetUser_Handler
    /go/pkg/mod/github.com/wwi21seb-projekt/alpha-shared@v0.21.2-0.20240623170543-b86b7a8bf346/proto/user/user-service_grpc.pb.go:461
google.golang.org/grpc.(*Server).processUnaryRPC
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1379
google.golang.org/grpc.(*Server).handleStream
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
    /go/pkg/mod/google.golang.org/grpc@v1.64.0/server.go:1029
```

Im zweiten Fall sieht man klar und deutlich, wo der panic eingebaut wurde:

```
github.com/wwi21seb-projekt/alpha-services/src/user-service/handler.userService.GetUser
    /go/src/serveralpha/handler/user.go:55
```